### PR TITLE
Ajuste creando colchón.

### DIFF
--- a/Mock Nequi/Logic/application_accesor_manager.rb
+++ b/Mock Nequi/Logic/application_accesor_manager.rb
@@ -12,7 +12,7 @@ class ApplicationAccesorManager
     raise 'El usuario ya existe' if possible_user.count != 0
     @actual_session.database_accessor.user_queries.create_user(email, first_name, last_name, encrypted_pass)
     @actual_session.database_accessor.account_queries.create_main_account_from_email(email)
-    @actual_session.database_accessor.account_queries.create_mattress_from_email(email)
+    @actual_session.database_accessor.mattress_queries.create_mattress_from_email(email)
   end
 
   def login_new(email, password)


### PR DESCRIPTION
Al registrar un nuevo usuario se presentaba el siguiente error:
Error: undefined method `create_mattress_from_email' for #<AccountQueries:0x00000000029f58b0>Did you mean?  create_main_account_from_email

Este error impedía que el colchón se creara, por lo que toda la funcionalidad que tenía que ver con este item no funcionaba.

Se realizó el ajuste en 'Mock Nequi\Logic\application_accesor_manager.rb'.